### PR TITLE
Move deleted wallpapers to Trash instead of permanently removing

### DIFF
--- a/app/main/ManagerApp.swift
+++ b/app/main/ManagerApp.swift
@@ -618,7 +618,7 @@ private func findButton(with title: String, in view: NSView) -> NSButton? {
     
     private func delete_wp(_ wallpaper: endup_wp) {
         do {
-            try FileManager.default.removeItem(atPath: wallpaper.path)
+            try FileManager.default.trashItem(at: URL(fileURLWithPath: wallpaper.path), resultingItemURL: nil)
             service.fetch_wallpapers()
         } catch {
             print("while deleting wallpaper: \(error)")


### PR DESCRIPTION
- The red trash button in the manager currently calls `FileManager.removeItem(atPath:)`, which unlinks the file from disk immediately with no confirmation dialog. 
- This switches it to `FileManager.trashItem(at:resultingItemURL:)`, so deleted wallpapers go to `~/.Trash` and can be restored.
- One-line change in `app/main/ManagerApp.swift`'s `delete_wp`.